### PR TITLE
Check registerCommands exists before invoking

### DIFF
--- a/src/CacheFallbackServiceProvider.php
+++ b/src/CacheFallbackServiceProvider.php
@@ -46,6 +46,8 @@ class CacheFallbackServiceProvider extends CacheServiceProvider
             return new MemcachedConnector;
         });
 
-        $this->registerCommands();
+        if(isset($this->registerCommands)) {
+        	$this->registerCommands();
+        }
     }
 }


### PR DESCRIPTION
No breaking changes but fixes compatibility up to at least Laravel 5.4